### PR TITLE
Fix .bat script

### DIFF
--- a/run_jira_sync.bat
+++ b/run_jira_sync.bat
@@ -1,5 +1,7 @@
 @echo off
 cd %~dp0
+git pull origin main
 git checkout main
+python -m pip install -r requirements.txt
 python main.py > run_jira_sync.log 2>&1
 echo Sync completed. Check run_jira_sync.log for details.

--- a/run_jira_sync.bat
+++ b/run_jira_sync.bat
@@ -2,3 +2,4 @@
 cd %~dp0
 git checkout main
 python main.py > run_jira_sync.log 2>&1
+echo Sync completed. Check run_jira_sync.log for details.


### PR DESCRIPTION
Enhance the `run_jira_sync.bat` script by adding a completion message and ensuring dependencies are installed before execution.